### PR TITLE
移除AFN3的下载功能调用

### DIFF
--- a/KF5SDK.podspec
+++ b/KF5SDK.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
         ss.public_header_files = 'KF5SDK/UI/Base/**/*.h','KF5SDK/UI/Category/**/*.h','KF5SDK/UI/Lib/**/*.h'
         ss.resources    = "KF5SDK/UI/KF5SDK.bundle"
         ss.dependency 'MBProgressHUD', '~> 1.0.0'
-        ss.dependency 'AFNetworking/Reachability', '~> 3.1.0'
+        ss.dependency 'AFNetworking/Reachability'
         ss.dependency 'YYText', '~> 1.0.7'
     end
 
@@ -49,7 +49,6 @@ Pod::Spec.new do |s|
         ss.dependency 'KF5SDK/Ticket'
         ss.dependency 'SDWebImage', '~> 3.8.2'
         ss.dependency 'TZImagePickerController', '~> 1.7.9'
-        ss.dependency 'AFNetworking/NSURLSession', '~> 3.1.0'
     end
 
 end


### PR DESCRIPTION
因为项目还用AFN2，无法直接接入SDK。

我看仓库里只有一处使用了AFN3的下载功能，我改成了系统的API实现。
由于不清楚这个地方什么时候会被使用，如果方便的话，麻烦你们看下会不会影响功能。
如果可以的话，感觉sdk的依赖还是少一点比较。

AFNetworkReachabilityManager 的初始化方法，2和3不一样，但是关系不是很大。手动fork修改一下就可以了。
